### PR TITLE
Move to matrix jobs for builds

### DIFF
--- a/.github/workflows/build-project.yml
+++ b/.github/workflows/build-project.yml
@@ -11,6 +11,21 @@ jobs:
   Build:
     name: Build
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        cross-file: [musl-static, mingw-w64, djgpp-gcc]
+        include:
+          # Linux x86_64
+          - cross-file: musl-static
+            file: x86_64
+          # Windows x86_64
+          - cross-file: mingw-w64
+            file: x86_64.exe
+          # Windows i386
+          - cross-file: djgpp-gcc
+            file: i386.exe
+            extra-step: "sed -i '/^ LINK_ARGS/d' build.ninja"
+
 
     steps:
     - name: Checkout repository
@@ -22,53 +37,22 @@ jobs:
        cd /opt
        wget https://github.com/andrewwutw/build-djgpp/releases/download/v3.1/djgpp-linux64-gcc1020.tar.bz2
        tar -xf djgpp-linux64-gcc1020.tar.bz2
-
-    - name: Configure toolchain for Linux x86_64
+ 
+    - name: Configure toolchain
       run: |
        mkdir build
        cd build
-       meson --cross-file ../cross-files/musl-static.txt ..
+       meson --cross-file ../cross-files/${{ matrix.cross-file }}.txt ..
+       ${{ matrix.extra-step }}
 
-    - name: Build project for Linux x86_64
+    - name: Build project
       run: |
        cd build
        ninja
 
-    - name: Upload Linux x86_64 artifact
+    - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:
-        name: memorylatency-x86_64
-        path: build/src/memorylatency-x86_64
-
-    - name: Configure toolchain for Windows x86_64
-      run: |
-       cd build
-       meson --wipe --cross-file ../cross-files/mingw-w64.txt ..
-       
-    - name: Build project for Windows x86_64
-      run: |
-       cd build
-       ninja
-
-    - name: Upload Windows x86_64 artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: memorylatency-x86_64.exe
-        path: build/src/memorylatency-x86_64.exe
-
-    - name: Configure toolchain for Windows i386
-      run: |
-       cd build
-       meson --wipe --cross-file ../cross-files/djgpp-gcc.txt ..
-       sed -i '/^ LINK_ARGS/d' build.ninja
-
-    - name: Build project for Windows i386
-      run: |
-       cd build
-       ninja
-
-    - name: Upload Windows i386 artifact
-      uses: actions/upload-artifact@v2
-      with:
-        name: memorylatency-i386.exe
-        path: build/src/memorylatency-i386.exe
+        name: memorylatency-${{ matrix.file }}
+        path: build/src/memorylatency-${{ matrix.file }}
+ 


### PR DESCRIPTION
Move away from a longer build file to a shorter one using matrices.